### PR TITLE
Make CLI-version more portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Put your knowledge base in the 'knowledgebases' folder (or upload them through t
 ## CLI-version
 This can be started by calling
 
-	.\main.php [-v] knowledge-base
+	./main.php [-v] knowledge-base
 
 Example:
 	
-	.\main.php knowledge.xml
+	./main.php knowledge.xml
 
 # Knowledge base format
 The knowledge base can contain rules, questions and goals to infer and is written using XML. See `www/knowledge-base-example.xml` for an example.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Put your knowledge base in the 'knowledgebases' folder (or upload them through t
 ## CLI-version
 This can be started by calling
 
-	main.php [-v] knowledge-base
+	.\main.php [-v] knowledge-base
 
 Example:
 	
-	main.php knowledge.xml
+	.\main.php knowledge.xml
 
 # Knowledge base format
 The knowledge base can contain rules, questions and goals to infer and is written using XML. See `www/knowledge-base-example.xml` for an example.

--- a/main.php
+++ b/main.php
@@ -1,4 +1,4 @@
-#!/usr/local/bin/php
+#!/usr/bin/env php
 <?php
 
 error_reporting(E_ALL);
@@ -95,3 +95,4 @@ function cli_ask(Question $question)
 }
 
 main($argc, $argv);
+


### PR DESCRIPTION
Different users might not have their php in /usr/local/bin but in some other directory (mine is in /usr/bin), so it is a good idea to use env to search for the correct location.

Additionally, update README.md such that users use "./main.php" and not "main.php".