### PR TITLE
Fix log-handling in Solver-class

### DIFF
--- a/solver.php
+++ b/solver.php
@@ -590,10 +590,9 @@ class Solver
 {
 	protected $log;
 
-	public function __construct(Logger $log)
+	public function __construct()
 	{
-		if ($log)
-			$this->log = $log;
+        $this->log = new WebLogger();
 	}
 
 	/**
@@ -805,9 +804,6 @@ class Solver
 
 	protected function log($format, array $arguments = [], $level = LOG_LEVEL_INFO)
 	{
-		if (!$this->log)
-			return;
-
 		$this->log->write($format, $arguments, $level);
 	}
 }

--- a/solver.php
+++ b/solver.php
@@ -595,6 +595,13 @@ class Solver
         $this->log = new WebLogger();
 	}
 
+    public static function withWebLogger(WebLogger $logger)
+    {
+        $instance = new self();
+        $instance->log=$logger;
+        return $instance;
+    }
+
 	/**
 	 * Probeer gegeven een initiële $knowledge state en een lijst van $goals
 	 * zo veel mogelijk $goals op te lossen. Dit doet hij door een stack met

--- a/util.php
+++ b/util.php
@@ -471,7 +471,16 @@ define('LOG_LEVEL_INFO', 2);
 
 define('LOG_LEVEL_VERBOSE', 1);
 
-interface Logger
+class WebLogger 
 {
-	public function write($format, $arguments, $level);
+	public $messages = array(array());
+
+	public function write($format, $arguments, $level)
+	{
+		$arguments = array_map(function($arg) {
+			return '<tt>' . Template::html(to_debug_string($arg)) . '</tt>';
+		}, $arguments);
+
+		$this->messages[count($this->messages) - 1][] = [$level, vsprintf($format, $arguments)];
+	}
 }

--- a/www/webfrontend.php
+++ b/www/webfrontend.php
@@ -36,7 +36,7 @@ class WebFrontend
 	{
 		$this->log = $this->getLog();
 
-		$this->solver = new Solver($this->log);
+		$this->solver = Solver::withWebLogger($this->log);
 
 		try
 		{

--- a/www/webfrontend.php
+++ b/www/webfrontend.php
@@ -17,25 +17,6 @@ function _decode($data)
 
 verbose(!empty($_GET['verbose']));
 
-class WebLogger implements Logger
-{
-	public $messages = array(array());
-
-	public function __wakeup()
-	{
-		$this->messages[] = array();
-	}
-
-	public function write($format, $arguments, $level)
-	{
-		$arguments = array_map(function($arg) {
-			return '<tt>' . Template::html(to_debug_string($arg)) . '</tt>';
-		}, $arguments);
-
-		$this->messages[count($this->messages) - 1][] = [$level, vsprintf($format, $arguments)];
-	}
-}
-
 class WebFrontend
 {
 	private $log;


### PR DESCRIPTION
It is me again. With this pull request, the CLI-version does not throw an error anymore (see first commit message). ~~However, I have not tested whether the debug-panel in the website-layout still works correctly...~~

Edit: Ok, I overlooked that in webfrontend.php the constructor with one argument is actually used and that this is the place where the Logger originally comes from. So the web-version needs a Solver with a one-argument-constructor and the CLI-version needs a Solver with a no-argument-construtor. Since PHP does not support multiple constructors, I have to use a factory-method.
I also tested the debug-panel in web-layout with "php -S localhost:8000", it works again.